### PR TITLE
Fix time format

### DIFF
--- a/xtradio-api.go
+++ b/xtradio-api.go
@@ -81,7 +81,7 @@ func (h songsHandler) readPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := stmt.Exec(vars["artist"], vars["title"], vars["file"], vars["title"], time.Now().Local().Format("2006-01-02"), time.Now().Local().Format("18:00:00"))
+	res, err := stmt.Exec(vars["artist"], vars["title"], vars["file"], vars["title"], time.Now().Local().Format("2006-01-02"), time.Now().Local().Format("15:04:05"))
 	if err != nil {
 		fmt.Println(time.Now(), "Adding data in to playlist failed", err)
 		return


### PR DESCRIPTION
"Layouts must use the reference time Mon Jan 2 15:04:05 MST 2006 to show the pattern with which to format/parse a given time/string." Golang is weird!!!